### PR TITLE
✨ Oppsett av mal med nødvendige felter

### DIFF
--- a/src/schemas/mal.ts
+++ b/src/schemas/mal.ts
@@ -1,5 +1,4 @@
-import Delmal from './delmal';
-import { FeltNavn, SanityTyper, Resultat, Ytelse } from '../typer';
+import { FeltNavn, SanityTyper, Resultat, Ytelse, DokumentNavn } from '../typer';
 
 const mal = (ytelse: Ytelse) => (resultat: Resultat) => ({
   title: 'Mal',
@@ -46,10 +45,16 @@ const mal = (ytelse: Ytelse) => (resultat: Resultat) => ({
       type: SanityTyper.STRING,
     },
     {
+      title: 'Brevtittel',
+      name: 'brevtittel',
+      type: SanityTyper.OBJECT,
+      fields: [{ name: 'tittelNB', title: 'Bokmål', type: SanityTyper.STRING }],
+    },
+    {
       title: 'Delmaler',
       name: 'delmaler',
       type: SanityTyper.ARRAY,
-      of: [Delmal],
+      of: [{ type: 'reference', to: [{ type: DokumentNavn.DELMAL }] }],
     },
   ],
 });

--- a/src/schemas/mal.ts
+++ b/src/schemas/mal.ts
@@ -5,6 +5,20 @@ const mal = (ytelse: Ytelse) => (resultat: Resultat) => ({
   title: 'Mal',
   name: `${ytelse}_${resultat}`,
   type: SanityTyper.DOCUMENT,
+  preview: {
+    select: {
+      visningsnavn: FeltNavn.VISNINGSNAVN,
+      publisert: FeltNavn.PUBLISERT,
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    prepare(selection: any) {
+      const { visningsnavn, publisert } = selection;
+      return {
+        title: visningsnavn,
+        subtitle: publisert && 'PUBLISERT',
+      };
+    },
+  },
   fields: [
     {
       title: 'Publisert',

--- a/src/schemas/mal.ts
+++ b/src/schemas/mal.ts
@@ -1,3 +1,5 @@
+import { StringRule } from 'sanity';
+
 import { FeltNavn, SanityTyper, Resultat, Ytelse, DokumentNavn } from '../typer';
 
 const mal = (ytelse: Ytelse) => (resultat: Resultat) => ({
@@ -43,12 +45,20 @@ const mal = (ytelse: Ytelse) => (resultat: Resultat) => ({
       title: 'Visningsnavn',
       name: FeltNavn.VISNINGSNAVN,
       type: SanityTyper.STRING,
+      validation: (Rule: StringRule) => [Rule.required().error('Brevet må ha et visningsnavn')],
     },
     {
       title: 'Brevtittel',
       name: 'brevtittel',
       type: SanityTyper.OBJECT,
-      fields: [{ name: 'tittelNB', title: 'Bokmål', type: SanityTyper.STRING }],
+      fields: [
+        {
+          name: 'tittelNB',
+          title: 'Bokmål',
+          type: SanityTyper.STRING,
+          validation: (Rule: StringRule) => [Rule.required().error('Brevet må ha en tittel')],
+        },
+      ],
     },
     {
       title: 'Delmaler',

--- a/src/schemas/mal.ts
+++ b/src/schemas/mal.ts
@@ -1,72 +1,74 @@
-import { StringRule, defineField } from 'sanity';
+import { StringRule, defineField, defineType } from 'sanity';
 
-import { FeltNavn, SanityTyper, Resultat, Ytelse, DokumentNavn } from '../typer';
+import { Resultat, Ytelse, DokumentNavn } from '../typer';
 
-const mal = (ytelse: Ytelse) => (resultat: Resultat) => ({
-  title: 'Mal',
-  name: `${ytelse}_${resultat}`,
-  type: SanityTyper.DOCUMENT,
-  preview: {
-    select: {
-      visningsnavn: FeltNavn.VISNINGSNAVN,
-      publisert: FeltNavn.PUBLISERT,
+const mal = (ytelse: Ytelse) => (resultat: Resultat) =>
+  defineType({
+    title: 'Mal',
+    name: `${ytelse}_${resultat}`,
+    type: 'document',
+    preview: {
+      select: {
+        visningsnavn: 'visningsnavn',
+        publisert: 'publisert',
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      prepare(selection: any) {
+        const { visningsnavn, publisert } = selection;
+        return {
+          title: visningsnavn,
+          subtitle: publisert && 'PUBLISERT',
+        };
+      },
     },
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    prepare(selection: any) {
-      const { visningsnavn, publisert } = selection;
-      return {
-        title: visningsnavn,
-        subtitle: publisert && 'PUBLISERT',
-      };
-    },
-  },
-  fields: [
-    defineField({
-      title: 'Publisert',
-      name: 'publisert',
-      description: 'Sett denne til publisert når brevmalen skal vises i saksbehandlingsløsningen.',
-      type: 'boolean',
-    }),
-    defineField({
-      title: 'Ytelse',
-      name: 'ytelse',
-      type: 'string',
-      initialValue: ytelse,
-      readOnly: true,
-    }),
-    defineField({
-      title: 'Resultat',
-      name: 'resultat',
-      type: 'string',
-      initialValue: resultat,
-      readOnly: true,
-    }),
-    defineField({
-      title: 'Visningsnavn',
-      name: 'visningsnavn',
-      type: 'string',
-      validation: (rule: StringRule) => rule.required().error('Brevet må ha et visningsnavn'),
-    }),
-    defineField({
-      title: 'Brevtittel',
-      name: 'brevtittel',
-      type: 'object',
-      fields: [
-        defineField({
-          name: 'tittelNB',
-          title: 'Bokmål',
-          type: 'string',
-          validation: (rule) => rule.required().error('Brevet må ha en tittel på bokmål'),
-        }),
-      ],
-    }),
-    defineField({
-      title: 'Delmaler',
-      name: 'delmaler',
-      type: 'array',
-      of: [{ type: 'reference', to: [{ type: DokumentNavn.DELMAL }] }],
-    }),
-  ],
-});
+    fields: [
+      defineField({
+        title: 'Publisert',
+        name: 'publisert',
+        description:
+          'Sett denne til publisert når brevmalen skal vises i saksbehandlingsløsningen.',
+        type: 'boolean',
+      }),
+      defineField({
+        title: 'Ytelse',
+        name: 'ytelse',
+        type: 'string',
+        initialValue: ytelse,
+        readOnly: true,
+      }),
+      defineField({
+        title: 'Resultat',
+        name: 'resultat',
+        type: 'string',
+        initialValue: resultat,
+        readOnly: true,
+      }),
+      defineField({
+        title: 'Visningsnavn',
+        name: 'visningsnavn',
+        type: 'string',
+        validation: (rule: StringRule) => rule.required().error('Brevet må ha et visningsnavn'),
+      }),
+      defineField({
+        title: 'Brevtittel',
+        name: 'brevtittel',
+        type: 'object',
+        fields: [
+          defineField({
+            name: 'tittelNB',
+            title: 'Bokmål',
+            type: 'string',
+            validation: (rule) => rule.required().error('Brevet må ha en tittel på bokmål'),
+          }),
+        ],
+      }),
+      defineField({
+        title: 'Delmaler',
+        name: 'delmaler',
+        type: 'array',
+        of: [{ type: 'reference', to: [{ type: DokumentNavn.DELMAL }] }],
+      }),
+    ],
+  });
 
 export default mal;

--- a/src/schemas/mal.ts
+++ b/src/schemas/mal.ts
@@ -1,4 +1,4 @@
-import { StringRule } from 'sanity';
+import { StringRule, defineField } from 'sanity';
 
 import { FeltNavn, SanityTyper, Resultat, Ytelse, DokumentNavn } from '../typer';
 
@@ -21,51 +21,51 @@ const mal = (ytelse: Ytelse) => (resultat: Resultat) => ({
     },
   },
   fields: [
-    {
+    defineField({
       title: 'Publisert',
-      name: FeltNavn.PUBLISERT,
+      name: 'publisert',
       description: 'Sett denne til publisert når brevmalen skal vises i saksbehandlingsløsningen.',
       type: 'boolean',
-    },
-    {
+    }),
+    defineField({
       title: 'Ytelse',
-      name: FeltNavn.YTELSE,
-      type: SanityTyper.STRING,
+      name: 'ytelse',
+      type: 'string',
       initialValue: ytelse,
       readOnly: true,
-    },
-    {
+    }),
+    defineField({
       title: 'Resultat',
-      name: FeltNavn.RESULTAT,
-      type: SanityTyper.STRING,
+      name: 'resultat',
+      type: 'string',
       initialValue: resultat,
       readOnly: true,
-    },
-    {
+    }),
+    defineField({
       title: 'Visningsnavn',
-      name: FeltNavn.VISNINGSNAVN,
-      type: SanityTyper.STRING,
-      validation: (Rule: StringRule) => [Rule.required().error('Brevet må ha et visningsnavn')],
-    },
-    {
+      name: 'visningsnavn',
+      type: 'string',
+      validation: (rule: StringRule) => rule.required().error('Brevet må ha et visningsnavn'),
+    }),
+    defineField({
       title: 'Brevtittel',
       name: 'brevtittel',
-      type: SanityTyper.OBJECT,
+      type: 'object',
       fields: [
-        {
+        defineField({
           name: 'tittelNB',
           title: 'Bokmål',
-          type: SanityTyper.STRING,
-          validation: (Rule: StringRule) => [Rule.required().error('Brevet må ha en tittel')],
-        },
+          type: 'string',
+          validation: (rule) => rule.required().error('Brevet må ha en tittel på bokmål'),
+        }),
       ],
-    },
-    {
+    }),
+    defineField({
       title: 'Delmaler',
       name: 'delmaler',
-      type: SanityTyper.ARRAY,
+      type: 'array',
       of: [{ type: 'reference', to: [{ type: DokumentNavn.DELMAL }] }],
-    },
+    }),
   ],
 });
 

--- a/src/schemas/mal.ts
+++ b/src/schemas/mal.ts
@@ -12,8 +12,7 @@ const mal = (ytelse: Ytelse) => (resultat: Resultat) =>
         visningsnavn: 'visningsnavn',
         publisert: 'publisert',
       },
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      prepare(selection: any) {
+      prepare(selection) {
         const { visningsnavn, publisert } = selection;
         return {
           title: visningsnavn,

--- a/src/typer.ts
+++ b/src/typer.ts
@@ -8,12 +8,6 @@ export enum DokumentNavn {
 
 export enum FeltNavn {
   API_NAVN = 'apiNavn',
-  BOKMÅL = 'nb',
-  NYNORSK = 'nn',
-  PUBLISERT = 'publisert',
-  RESULTAT = 'resultat',
-  VISNINGSNAVN = 'visningsnavn',
-  YTELSE = 'ytelse',
 }
 
 export enum SanityTyper {

--- a/src/typer.ts
+++ b/src/typer.ts
@@ -12,7 +12,6 @@ export enum FeltNavn {
   NYNORSK = 'nn',
   PUBLISERT = 'publisert',
   RESULTAT = 'resultat',
-  TYPE = 'type',
   VISNINGSNAVN = 'visningsnavn',
   YTELSE = 'ytelse',
 }


### PR DESCRIPTION
Har gått vekk fra bruk av enums for å definere `SanityTyper` og `Feltnavn` for å kunne bruke `defineType()` og `defineField()` som gir litt bedre hjelp med typing under utvikling (fortsatt ikke optimalt 😢) 

<img width="1725" alt="image" src="https://github.com/navikt/tilleggsstonader-brev-sanity/assets/46678893/e09e4d39-3e0e-4a63-a900-6cb449e604af">
