### PR TITLE
Styling av previews

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "sanity"
   ],
   "dependencies": {
+    "@sanity/ui": "^1.8.2",
     "@sanity/vision": "^3.16.7",
     "date-fns": "^2.30.0",
     "eslint": "^8.50.0",

--- a/src/komponenter/DelmalReferansePreview.tsx
+++ b/src/komponenter/DelmalReferansePreview.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+
+import { Badge, Box, Flex, Inline } from '@sanity/ui';
+import { PreviewProps } from 'sanity';
+
+type Props = PreviewProps & {
+  visningsnavn: string;
+  skalAlltidMed?: boolean;
+  skalVisesIBrevmeny?: boolean;
+};
+
+const DelmalReferansePreview = (props: PreviewProps) => {
+  const castProps = props as Props;
+  const { visningsnavn, skalAlltidMed, skalVisesIBrevmeny } = castProps;
+
+  return (
+    <Flex align="center">
+      <Box flex={1}>{visningsnavn}</Box>
+      <Inline space={2}>
+        {skalAlltidMed && (
+          <Badge mode="outline" tone="positive">
+            Alltid med
+          </Badge>
+        )}
+        {skalVisesIBrevmeny && (
+          <Badge mode="outline" tone="positive">
+            Vises i brevmeny
+          </Badge>
+        )}
+      </Inline>
+    </Flex>
+  );
+};
+
+export default DelmalReferansePreview;

--- a/src/komponenter/FritekstområdePreview.tsx
+++ b/src/komponenter/FritekstområdePreview.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+import { Stack, Card, Flex, Text } from '@sanity/ui';
+
+const FritekstPreview: React.FC = () => (
+  <Stack>
+    <Card padding={3} tone={'caution'}>
+      <Flex justify="center">
+        <Text>Fritekstområde</Text>
+      </Flex>
+    </Card>
+  </Stack>
+);
+
+export default FritekstPreview;

--- a/src/komponenter/ValgReferansePreview.tsx
+++ b/src/komponenter/ValgReferansePreview.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+
+import { Badge, Box, Heading, Stack } from '@sanity/ui';
+import { PreviewProps } from 'sanity';
+
+const ValgReferansePreview = (props: PreviewProps) => {
+  return (
+    <Stack space={3} padding={2}>
+      <Box>
+        <Badge tone="primary">Valgfelt</Badge>
+      </Box>
+      <Heading size={1}>{props.renderDefault(props)}</Heading>
+    </Stack>
+  );
+};
+
+export default ValgReferansePreview;

--- a/src/schemas/blockEditor.ts
+++ b/src/schemas/blockEditor.ts
@@ -18,6 +18,7 @@ const blockEditor = (målform: string, tittel: string, erDelmal: boolean) => ({
           {
             type: SanityTyper.REFERENCE,
             to: [{ type: DokumentNavn.VARIABEL }],
+            icon: () => 'V',
           },
         ],
       },

--- a/src/schemas/felter/fritekst.ts
+++ b/src/schemas/felter/fritekst.ts
@@ -1,9 +1,11 @@
+import FritekstPreview from '../../komponenter/FritekstområdePreview';
 import { DokumentNavn } from '../../typer';
 
 const Fritekst = {
   title: 'Fritekst',
   name: DokumentNavn.FRITEKST,
   type: 'document',
+  components: { preview: FritekstPreview },
   fields: [
     { name: 'dummyfelt', type: 'string', initialValue: 'dummyverdi', readOnly: true, hidden: true }, // Brukes ikke til noen ting. Lagt til fordi sanity krever minst et felt
   ],

--- a/src/schemas/referanser/delmalReferanse.ts
+++ b/src/schemas/referanser/delmalReferanse.ts
@@ -1,11 +1,20 @@
 import { defineField } from 'sanity';
 
-import { DokumentNavn } from '../../typer';
+import DelmalReferansePreview from '../../komponenter/DelmalReferansePreview';
+import { DokumentNavn, FeltNavn } from '../../typer';
 
 const delmalReferanse = defineField({
   name: DokumentNavn.DELMAL_REFERANSE,
   title: 'Delmal referanse',
   type: 'object',
+  components: { preview: DelmalReferansePreview },
+  preview: {
+    select: {
+      visningsnavn: `${DokumentNavn.DELMAL_REFERANSE}.${FeltNavn.VISNINGSNAVN}`,
+      skalAlltidMed: 'visningsdetaljer.skalAlltidMed',
+      skalVisesIBrevmeny: 'visningsdetaljer.skalVisesIBrevmeny',
+    },
+  },
   fields: [
     defineField({
       title: 'Delmal',

--- a/src/schemas/referanser/valgfeltReferanse.ts
+++ b/src/schemas/referanser/valgfeltReferanse.ts
@@ -1,17 +1,24 @@
 import { defineField } from 'sanity';
 
-import { DokumentNavn } from '../../typer';
+import ValgReferansePreview from '../../komponenter/ValgReferansePreview';
+import { DokumentNavn, FeltNavn } from '../../typer';
 
 const valgfeltReferanse = (erDelmal: boolean) =>
   defineField({
     name: DokumentNavn.VALGFELT_REFERANSE,
-    title: 'Valgfelt referanse',
+    title: 'Valgfelt',
     type: 'object',
     hidden: !erDelmal,
+    components: { preview: ValgReferansePreview },
+    preview: {
+      select: {
+        title: `${DokumentNavn.VALGFELT}.${FeltNavn.VISNINGSNAVN}`,
+      },
+    },
     fields: [
       defineField({
         title: 'Valgfelt',
-        name: 'valgfelt',
+        name: DokumentNavn.VALGFELT,
         type: 'reference',
         to: [{ type: DokumentNavn.VALGFELT }],
       }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1795,7 +1795,7 @@
     "@sanity/client" "^6.4.9"
     "@types/react" "^18.0.25"
 
-"@sanity/ui@^1.7.2":
+"@sanity/ui@^1.7.2", "@sanity/ui@^1.8.2":
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/@sanity/ui/-/ui-1.8.2.tgz#70f0c55e3bdd04b662d3cd84af168d4e27adfc2c"
   integrity sha512-XWtVdIG1PWBEiNPcObRfXsX/EPhiPCHMmfdn+frPIVLTLnoQnNju3W9UQAWec+BwjXBCpPtfc36AoiQSDUkxzw==


### PR DESCRIPTION
Lagt til penere visning av valg og fritekst i delmal: 
<img width="518" alt="image" src="https://github.com/navikt/tilleggsstonader-brev-sanity/assets/46678893/8548dc4d-986b-40c2-a656-88a33fd91a5a">

Vise mer info om delmal i brevmal: 
<img width="620" alt="image" src="https://github.com/navikt/tilleggsstonader-brev-sanity/assets/46678893/e7aa0885-6357-4860-a4cb-0c2cc662c9b3">

