### PR TITLE
Preview av valg og fjerne visningsdetaljer

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "sanity"
   ],
   "dependencies": {
+    "@portabletext/react": "^3.0.9",
+    "@sanity/client": "^6.4.12",
     "@sanity/ui": "^1.8.2",
     "@sanity/vision": "^3.16.7",
     "date-fns": "^2.30.0",

--- a/src/komponenter/TekstPreview.tsx
+++ b/src/komponenter/TekstPreview.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+
+import { PortableText } from '@portabletext/react';
+import { Text, Card } from '@sanity/ui';
+
+import { useSanityQuery } from '../utils/sanity';
+
+interface Props {
+  id: string;
+}
+
+const TekstPreview: React.FC<Props> = ({ id }) => {
+  const query = `*[_id=="${id}"][0]`;
+
+  const { data, error } = useSanityQuery(query);
+
+  if (error) {
+    return (
+      <Card padding={3} tone="critical">
+        <Text>Det skjedde en feil</Text>
+      </Card>
+    );
+  }
+
+  if (!data) {
+    return (
+      <Card padding={3} tone="caution">
+        <Text>Laster valg...</Text>
+      </Card>
+    );
+  }
+
+  const valg = data as {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    nb: any;
+  };
+
+  return (
+    <Card border padding={2}>
+      <PortableText value={valg.nb} />
+    </Card>
+  );
+};
+
+export default TekstPreview;

--- a/src/komponenter/ValgReferansePreview.tsx
+++ b/src/komponenter/ValgReferansePreview.tsx
@@ -1,15 +1,32 @@
 import * as React from 'react';
 
-import { Badge, Box, Heading, Stack } from '@sanity/ui';
+import { Badge, Box, Flex, Heading, Stack } from '@sanity/ui';
 import { PreviewProps } from 'sanity';
 
+import FritekstPreview from './FritekstområdePreview';
+import TekstPreview from './TekstPreview';
+
+type Props = PreviewProps & {
+  valg?: { _type: string; _ref: string }[];
+};
+
 const ValgReferansePreview = (props: PreviewProps) => {
+  const castProps = props as Props;
+  const { valg } = castProps;
+
   return (
     <Stack space={3} padding={2}>
       <Box>
         <Badge tone="primary">Valgfelt</Badge>
       </Box>
       <Heading size={1}>{props.renderDefault(props)}</Heading>
+      {valg?.map((v, indeks) => (
+        <Flex padding={2} gap={2} direction="column">
+          <Heading size={0}>Valg {indeks + 1}:</Heading>
+          {v._type === 'reference' && <TekstPreview id={v._ref} />}
+          {v._type === 'fritekst' && <FritekstPreview />}
+        </Flex>
+      ))}
     </Stack>
   );
 };

--- a/src/komponenter/ValgReferansePreview.tsx
+++ b/src/komponenter/ValgReferansePreview.tsx
@@ -5,6 +5,7 @@ import { PreviewProps } from 'sanity';
 
 import FritekstPreview from './FritekstområdePreview';
 import TekstPreview from './TekstPreview';
+import { DokumentNavn } from '../typer';
 
 type Props = PreviewProps & {
   valg?: { _type: string; _ref: string }[];
@@ -24,7 +25,7 @@ const ValgReferansePreview = (props: PreviewProps) => {
         <Flex padding={2} gap={2} direction="column">
           <Heading size={0}>Valg {indeks + 1}:</Heading>
           {v._type === 'reference' && <TekstPreview id={v._ref} />}
-          {v._type === 'fritekst' && <FritekstPreview />}
+          {v._type === DokumentNavn.FRITEKST && <FritekstPreview />}
         </Flex>
       ))}
     </Stack>

--- a/src/schemas/referanser/valgfeltReferanse.ts
+++ b/src/schemas/referanser/valgfeltReferanse.ts
@@ -13,6 +13,7 @@ const valgfeltReferanse = (erDelmal: boolean) =>
     preview: {
       select: {
         title: `${DokumentNavn.VALGFELT}.${FeltNavn.VISNINGSNAVN}`,
+        valg: `${DokumentNavn.VALGFELT}.valg`,
       },
     },
     fields: [

--- a/src/schemas/referanser/valgfeltReferanse.ts
+++ b/src/schemas/referanser/valgfeltReferanse.ts
@@ -22,25 +22,6 @@ const valgfeltReferanse = (erDelmal: boolean) =>
         type: 'reference',
         to: [{ type: DokumentNavn.VALGFELT }],
       }),
-      defineField({
-        title: 'Visningsdetaljer',
-        name: 'visningsdetaljer',
-        type: 'object',
-        fields: [
-          defineField({
-            title: 'Skal valgfeltet alltid være med?',
-            name: 'skalAlltidMed',
-            type: 'boolean',
-            initialValue: false,
-          }),
-          defineField({
-            title: 'Skal valgfeltet vises i brevmenyen?',
-            name: 'skalVisesIBrevmeny',
-            type: 'boolean',
-            initialValue: false,
-          }),
-        ],
-      }),
     ],
   });
 

--- a/src/utils/sanity.ts
+++ b/src/utils/sanity.ts
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react';
+
+import { createClient } from '@sanity/client';
+
+export const client = (brukCache: boolean) => {
+  return createClient({
+    projectId: 's0grjk9v',
+    dataset: 'production',
+    useCdn: brukCache,
+    withCredentials: true,
+  });
+};
+
+export async function hentFraSanity(
+  query: string,
+  brukCache: boolean = true,
+  brukSessionStorage: boolean = true,
+) {
+  const datasett = window.location.pathname.split('/')[1];
+  const key = datasett + ';' + query;
+  const cachedHits = sessionStorage.getItem(key);
+
+  if (cachedHits && brukSessionStorage) {
+    return JSON.parse(cachedHits);
+  } else {
+    const response = await client(brukCache).fetch(query);
+    sessionStorage.setItem(key, JSON.stringify(response));
+    return response;
+  }
+}
+
+export function useSanityQuery(
+  query: string,
+  brukCache: boolean = true,
+  brukSessionStorage: boolean = true,
+) {
+  const [data, setData] = useState<unknown>();
+  const [error, setError] = useState<unknown>();
+
+  useEffect(() => {
+    hentFraSanity(query, brukCache, brukSessionStorage)
+      .then((response) => setData(response))
+      .catch((error) => setError(error));
+  }, [query, brukCache, brukSessionStorage]);
+
+  return { data, error };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1581,6 +1581,26 @@
     picocolors "^1.0.0"
     tslib "^2.6.0"
 
+"@portabletext/react@^3.0.9":
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/@portabletext/react/-/react-3.0.9.tgz#c9a20c99a7925cea4e76079dcdee397999448034"
+  integrity sha512-BAIhClkMs5IwDkCd2F7xF5/fsvFm39kpdZmGnLfCpZudb5zDY8JNa6eeyRO50rL+VwozXb8qJEBkVBTp3CGcEw==
+  dependencies:
+    "@portabletext/toolkit" "^2.0.9"
+    "@portabletext/types" "^2.0.7"
+
+"@portabletext/toolkit@^2.0.9":
+  version "2.0.9"
+  resolved "https://registry.yarnpkg.com/@portabletext/toolkit/-/toolkit-2.0.9.tgz#530ca788a8db8a5feb7f3eb84c149c43a4501d9a"
+  integrity sha512-6/P/fsCGLFhztVGJRwIMePmwGbOH1Uvoim04XPh38pcC+wWT3KJ97Hn1HPWmuxd9kGdxyySQpThfYZbSmroGpg==
+  dependencies:
+    "@portabletext/types" "^2.0.7"
+
+"@portabletext/types@^2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@portabletext/types/-/types-2.0.7.tgz#e4c97bcebd15901d72a218ebb6595ddea7cdfead"
+  integrity sha512-kWjS2lguGKHYDsHeK83cXonuYQCIP4mfNwnTjCdDpIPf7CQ4eTuKjYKxJ2w2aksbsh1DwSk1h+xZ64ADiNdTGg==
+
 "@rexxars/react-json-inspector@^8.0.1":
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/@rexxars/react-json-inspector/-/react-json-inspector-8.0.1.tgz#cd903eaf7bec40d4e870e1085619af5067196c59"
@@ -1638,7 +1658,7 @@
     golden-fleece "^1.0.9"
     pkg-dir "^5.0.0"
 
-"@sanity/client@^6.4.9":
+"@sanity/client@^6.4.12", "@sanity/client@^6.4.9":
   version "6.4.12"
   resolved "https://registry.yarnpkg.com/@sanity/client/-/client-6.4.12.tgz#34a1a543669157eba533e64b60359984ef9c6d33"
   integrity sha512-TuseXC5z0CORO7wKMmhNTiKy/8vjWsN7/PTMy53MUBshlMYE2xPad2QFw1zr+n/7qvNNc/CQ6Y2wVnaXU9PHVg==


### PR DESCRIPTION
### Hvorfor? ✨ 
Fjernet visningsdetaljer fra valg fordi valget skal alltid være med i en delmal og den skal alltid vises i brevmal. Nå velger man kun referansen og ikke mer: 
![image](https://github.com/navikt/tilleggsstonader-brev-sanity/assets/46678893/e720a573-dcc0-4901-a822-8633615b0944)


Endret visning av valg så man får preview av valg (tekstinnhold og/eller fritekstområde): 
![image](https://github.com/navikt/tilleggsstonader-brev-sanity/assets/46678893/19f98eaf-d673-4a6c-b7bd-0a414a4891b9)
