### PR TITLE
🐛  Skal kunne lage valgfelt uten fritekst

### DIFF
--- a/src/schemas/valgfelt.ts
+++ b/src/schemas/valgfelt.ts
@@ -31,9 +31,7 @@ const Valgfelt = defineType({
             (v) => v._type === DokumentNavn.FRITEKST,
           );
 
-          return fritekstfelter.length <= 1
-            ? true
-            : 'Du kan kun legge til fritekst som et valg 1 gang';
+          return fritekstfelter.length <= 1 || 'Du kan kun legge til fritekst som et valg 1 gang';
         }),
     }),
   ],

--- a/src/schemas/valgfelt.ts
+++ b/src/schemas/valgfelt.ts
@@ -31,7 +31,7 @@ const Valgfelt = defineType({
             (v) => v._type === DokumentNavn.FRITEKST,
           );
 
-          return fritekstfelter.length === 1
+          return fritekstfelter.length <= 1
             ? true
             : 'Du kan kun legge til fritekst som et valg 1 gang';
         }),


### PR DESCRIPTION
Validering ble lagt til for å gjøre det umulig å legge inn flere enn et fritekstfelt, men sjekket kun at fritekst var lik 1 og ikke `<=1` 🤠 