### PR TITLE
🐛 Skal være mulig å navigere via en variabelreferanse

### DIFF
--- a/src/schemas/blockEditor.ts
+++ b/src/schemas/blockEditor.ts
@@ -1,3 +1,5 @@
+import { defineField } from 'sanity';
+
 import valgfeltReferanse from './referanser/valgfeltReferanse';
 import { DokumentNavn, SanityTyper } from '../typer';
 
@@ -15,9 +17,9 @@ const blockEditor = (målform: string, tittel: string, erDelmal: boolean) => ({
       type: SanityTyper.BLOCK,
       marks: {
         annotations: [
-          {
+          defineField({
             name: 'variabel',
-            type: SanityTyper.OBJECT,
+            type: 'object',
             title: 'Variabel',
             icon: () => 'V',
             fields: [
@@ -26,9 +28,10 @@ const blockEditor = (målform: string, tittel: string, erDelmal: boolean) => ({
                 title: 'Variabel',
                 type: 'reference',
                 to: [{ type: DokumentNavn.VARIABEL }],
+                validation: (rule) => rule.required(),
               },
             ],
-          },
+          }),
         ],
       },
     },

--- a/src/schemas/blockEditor.ts
+++ b/src/schemas/blockEditor.ts
@@ -16,9 +16,18 @@ const blockEditor = (målform: string, tittel: string, erDelmal: boolean) => ({
       marks: {
         annotations: [
           {
-            type: SanityTyper.REFERENCE,
-            to: [{ type: DokumentNavn.VARIABEL }],
+            name: 'variabel',
+            type: SanityTyper.OBJECT,
+            title: 'Variabel',
             icon: () => 'V',
+            fields: [
+              {
+                name: 'variabelreferanse',
+                title: 'Variabel',
+                type: 'reference',
+                to: [{ type: DokumentNavn.VARIABEL }],
+              },
+            ],
           },
         ],
       },


### PR DESCRIPTION
Variabelreferanser kunne ikke navigeres til via teksten den lå inne i. Løsningen ble å gjøre referansen inne i et objekt, men fordi referansen tidligere ikke hadde et navn ⚠️ _fjernes alle referanser til variabler som ligger i brev til nå_ ⚠️ 

Før:
<img width="693" alt="image" src="https://github.com/navikt/tilleggsstonader-brev-sanity/assets/46678893/e9d3e74f-2afe-4652-861a-3e1037882018">

Etter: 
<img width="639" alt="image" src="https://github.com/navikt/tilleggsstonader-brev-sanity/assets/46678893/aa04eaaa-13bd-4650-95fd-8736d5cdd1c1">
