### PR TITLE
Mappestruktur for Læremidler

### DIFF
--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -1,6 +1,6 @@
 import { visionTool } from '@sanity/vision';
 import { AuthConfig, defineConfig } from 'sanity';
-import { deskTool } from 'sanity/desk';
+import { structureTool } from 'sanity/structure';
 
 import { schemaTypes } from './src/schemas';
 import { structure } from './structure';
@@ -25,7 +25,7 @@ export default defineConfig({
   projectId: 's0grjk9v',
   dataset: 'production',
 
-  plugins: [deskTool({ structure }), visionTool()],
+  plugins: [structureTool({ structure }), visionTool()],
 
   schema: {
     types: schemaTypes,

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -4,5 +4,14 @@ import Variabel from './felter/variabel';
 import Tekst from './tekst';
 import Valgfelt from './valgfelt';
 import barnetilsyn from './ytelse/barnetilsyn';
+import laremidler from './ytelse/laremidler';
 
-export const schemaTypes = [...barnetilsyn(), Delmal, Fritekstområde, Tekst, Variabel, Valgfelt];
+export const schemaTypes = [
+  ...barnetilsyn(),
+  ...laremidler(),
+  Delmal,
+  Fritekstområde,
+  Tekst,
+  Variabel,
+  Valgfelt,
+];

--- a/src/schemas/ytelse/laremidler.ts
+++ b/src/schemas/ytelse/laremidler.ts
@@ -1,0 +1,16 @@
+import { Resultat, Ytelse } from '../../typer';
+import mal from '../mal';
+
+const laremidler = () => {
+  const laremidlerMal = mal(Ytelse.LAREMIDLER);
+
+  return [
+    laremidlerMal(Resultat.INNVILGET),
+    laremidlerMal(Resultat.AVSLAG),
+    laremidlerMal(Resultat.FRITTSTAENDE),
+    laremidlerMal(Resultat.REVURDERING),
+    laremidlerMal(Resultat.OPPHOR),
+  ];
+};
+
+export default laremidler;

--- a/src/typer.ts
+++ b/src/typer.ts
@@ -26,10 +26,12 @@ export enum SanityTyper {
 
 export enum Ytelse {
   BARNETILSYN = 'BARNETILSYN',
+  LAREMIDLER = 'LAREMIDLER',
 }
 
 export const ytelseTittel: Record<Ytelse, string> = {
   BARNETILSYN: 'Barnetilsyn',
+  LAREMIDLER: 'Læremidler',
 };
 
 export enum Resultat {

--- a/structure.ts
+++ b/structure.ts
@@ -23,6 +23,13 @@ export const structure = (S: StructureBuilder, _context: StructureResolverContex
         lagTypemappe(Ytelse.BARNETILSYN, Resultat.REVURDERING),
         lagTypemappe(Ytelse.BARNETILSYN, Resultat.OPPHOR),
       ]),
+      lagYtelsemappe(Ytelse.LAREMIDLER, [
+        lagTypemappe(Ytelse.LAREMIDLER, Resultat.INNVILGET),
+        lagTypemappe(Ytelse.LAREMIDLER, Resultat.AVSLAG),
+        lagTypemappe(Ytelse.LAREMIDLER, Resultat.FRITTSTAENDE),
+        lagTypemappe(Ytelse.LAREMIDLER, Resultat.REVURDERING),
+        lagTypemappe(Ytelse.LAREMIDLER, Resultat.OPPHOR),
+      ]),
       S.divider(),
       ...S.documentTypeListItems().filter((listItem) =>
         ['delmal', 'variabel', 'valgfelt', 'tekst'].includes(listItem.getId() || ''),


### PR DESCRIPTION
Legger til Mappe-struktur for Læremidler som er lik som mappestrukturen for Barnetilsyn. Legger ikke til noen tekster.

Ny struktur:
![image](https://github.com/user-attachments/assets/d669f805-c16e-4386-9b14-6646e8ba8180)

***************

Erstatter bruken av deskTool (som er deprecated) med ny funksjonalitet: structureTool
